### PR TITLE
Allow serialization of full token objects

### DIFF
--- a/src/OAuth/Common/Token/AbstractToken.php
+++ b/src/OAuth/Common/Token/AbstractToken.php
@@ -122,9 +122,4 @@ abstract class AbstractToken implements TokenInterface
         && $this->getEndOfLife() !== TokenInterface::EOL_UNKNOWN
         && time() > $this->getEndOfLife();
     }
-
-    public function __sleep()
-    {
-        return ['accessToken'];
-    }
 }


### PR DESCRIPTION
In https://github.com/carlos-mg89/PHPoAuthLib/commit/f08a062d5abe903a4092bcf92f855f6e2e7b676a
the AbstractToken::__sleep() method was added,
but it breaks serialization of request tokens (as stored in sessions).

Bug: https://github.com/samwilson/phpflickr/issues/50