### PR TITLE
don't rawurlencode null values

### DIFF
--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -54,7 +54,7 @@ class Signature implements SignatureInterface
         parse_str($uri->getQuery(), $queryStringData);
 
         foreach (array_merge($queryStringData, $params) as $key => $value) {
-            $signatureData[rawurlencode($key)] = rawurlencode($value);
+            $signatureData[rawurlencode($key)] = $value ? rawurlencode($value): $value;
         }
 
         ksort($signatureData);


### PR DESCRIPTION
Deprecated: rawurlencode(): Passing null to parameter #1 ($string) of type string is deprecated

This PR simply skips the rawurlencode if the value is null, to get rid of the above deprecation error.

* Check the PR has a meaningful description
* Set the PR as draft initially. When Scrutinizer check passes you can change it to ready to review
