### PR TITLE
Avoid passing null to rawurlencode()

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -222,7 +222,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $delimiter = '';
 
         foreach ($authParameters as $key => $value) {
-            $authorizationHeader .= $delimiter . rawurlencode($key) . '="' . rawurlencode($value) . '"';
+            $authorizationHeader .= $delimiter . rawurlencode($key) . '="' . rawurlencode($value ?? '') . '"';
             $delimiter = ', ';
         }
 

--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -54,7 +54,7 @@ class Signature implements SignatureInterface
         parse_str($uri->getQuery(), $queryStringData);
 
         foreach (array_merge($queryStringData, $params) as $key => $value) {
-            $signatureData[rawurlencode($key)] = rawurlencode($value);
+            $signatureData[rawurlencode($key)] = rawurlencode($value ?? '');
         }
 
         ksort($signatureData);


### PR DESCRIPTION
Passing null to rawurlencode() is now deprecated, so this coalescese null to the empty string.

Fixes #12
