### PR TITLE
Fixed the explicit nullable type issue

### DIFF
--- a/src/OAuth/OAuth1/Service/Redmine.php
+++ b/src/OAuth/OAuth1/Service/Redmine.php
@@ -19,7 +19,7 @@ class Redmine extends AbstractService
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,
-        UriInterface $baseApiUri
+        ?UriInterface $baseApiUri = null
     ) {
         parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
 

--- a/src/OAuth/OAuth2/Service/Yandex.php
+++ b/src/OAuth/OAuth2/Service/Yandex.php
@@ -24,7 +24,7 @@ class Yandex extends AbstractService
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),
-        UriInterface $baseApiUri = null
+        ?UriInterface $baseApiUri = null
     ) {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
 


### PR DESCRIPTION
Prominent deprecation in PHP 8.4:
This is a prominent deprecation in PHP 8.4 and legacy PHP applications will likely cause deprecation notices due to this change in PHP 8.4. The [suggested replacement](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated#change) is straight-forward, safe, and works in PHP 7.1 and later.